### PR TITLE
API 호출시 동아리 내 권한 검증 설정, 전역예외처리(Global Exception Handling) 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/src/main/java/com/ryc/api/ApiApplication.java
+++ b/src/main/java/com/ryc/api/ApiApplication.java
@@ -2,7 +2,9 @@ package com.ryc.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
+@EnableAspectJAutoProxy
 @SpringBootApplication
 public class ApiApplication {
 

--- a/src/main/java/com/ryc/api/v1/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/ryc/api/v1/applicant/controller/ApplicantController.java
@@ -2,6 +2,7 @@ package com.ryc.api.v1.applicant.controller;
 
 import com.ryc.api.v1.applicant.dto.response.GetAllApplicantResponse;
 import com.ryc.api.v1.applicant.service.ApplicantService;
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,8 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApplicantController {
     private final ApplicantService applicantService;
 
+    @HasAnyRoleSecured
     @GetMapping("/")
-    public ResponseEntity<?> getAllApplicants(@RequestParam(required = true) String recruitmentId) {
+    public ResponseEntity<?> getAllApplicants(@RequestParam(required = true) String clubId, String recruitmentId) {
         try {
             GetAllApplicantResponse response = applicantService.getAllApplicantsByRecruitmentId(recruitmentId);
             return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/ryc/api/v1/application/controller/ApplicationController.java
+++ b/src/main/java/com/ryc/api/v1/application/controller/ApplicationController.java
@@ -5,6 +5,8 @@ import com.ryc.api.v1.application.dto.request.CreateApplicationFormRequest;
 import com.ryc.api.v1.application.dto.request.UpdateAnswerAccessibilityRequest;
 import com.ryc.api.v1.application.dto.response.*;
 import com.ryc.api.v1.application.service.ApplicationService;
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import java.util.List;
 public class ApplicationController {
     private final ApplicationService applicationService;
 
+    @HasPresidentRoleSecured
     @PostMapping("/form")
     public ResponseEntity<?> createApplicationForm(@Valid @RequestBody CreateApplicationFormRequest body) {
         try {
@@ -51,8 +54,10 @@ public class ApplicationController {
         }
     }
 
+    @HasAnyRoleSecured
     @GetMapping("/")
-    public ResponseEntity<?> getApplication(@RequestParam(required = true) String stepId,
+    public ResponseEntity<?> getApplication(@RequestParam(required = true) String clubId,
+                                            @RequestParam(required = true) String stepId,
                                             @RequestParam(required = true) List<String> applicantIdList) {
         try {
             List<GetApplicationResponse> response = applicationService.findApplicationByApplicantId(stepId, applicantIdList);
@@ -62,11 +67,13 @@ public class ApplicationController {
         }
     }
 
+    @HasPresidentRoleSecured
     @PatchMapping("/questions/{questionId}")
-    public ResponseEntity<?> updateAnswerAccessibility(@PathVariable String questionId,
+    public ResponseEntity<?> updateAnswerAccessibility(@RequestParam(required = true) String clubId,
+                                                       @PathVariable String questionId,
                                                        @RequestBody @Valid UpdateAnswerAccessibilityRequest body) {
         try {
-            UpdateAnswerAccessibilityResponse response = applicationService.updateAnswerAccessibility(questionId,body);
+            UpdateAnswerAccessibilityResponse response = applicationService.updateAnswerAccessibility(questionId, body);
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());

--- a/src/main/java/com/ryc/api/v1/application/dto/request/CreateApplicationFormRequest.java
+++ b/src/main/java/com/ryc/api/v1/application/dto/request/CreateApplicationFormRequest.java
@@ -2,11 +2,15 @@ package com.ryc.api.v1.application.dto.request;
 
 import com.ryc.api.v1.application.domain.metadata.Field;
 import com.ryc.api.v1.application.dto.internal.QuestionDto;
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record CreateApplicationFormRequest(@NotEmpty(message = "stepId shouldn't be empty") String stepId,
-                                           @NotEmpty(message = "requiredFields shouldn't be empty (At least the NAME field must be required.)") List<Field> requiredFields,
-                                           @NotEmpty(message = "questions shouldn't be empty") List<QuestionDto> questions) {
+public record CreateApplicationFormRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be empty") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "stepId shouldn't be empty") String stepId,
+        @NotEmpty(message = "requiredFields shouldn't be empty (At least the NAME field must be required.)") List<Field> requiredFields,
+        @NotEmpty(message = "questions shouldn't be empty") List<QuestionDto> questions) {
 }

--- a/src/main/java/com/ryc/api/v1/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/ryc/api/v1/application/service/ApplicationServiceImpl.java
@@ -96,6 +96,8 @@ public class ApplicationServiceImpl implements ApplicationService {
         // 1.지원서 이름 불러오기
         Step step = stepRepository.findById(stepId)
                 .orElseThrow(() -> new NoSuchElementException("Step not found"));
+
+        //TODO: 해당 step 타입이 APPLICATION인지 확인하기
         String stepName = step.getStepName();
 
         //2. 지원서 필수 응답항목 불러오기
@@ -156,8 +158,10 @@ public class ApplicationServiceImpl implements ApplicationService {
                 throw new IllegalArgumentException("answer should not be null");
 
             if (question.getQuestionType() == QuestionType.MULTIPLE_CHOICE) {
+                // TODO: questionId와 함께 조회하는 것으로 수정. 해당 optionId가 해당 questionId의 산하 선지인지 확인하는 절차 필요
                 MultipleChoiceOption multipleChoiceOption = multipleChoiceOptionRepository.findById(answerDto.optionAnswerId())
                         .orElseThrow(() -> new NoSuchElementException("option answer not found"));
+
                 Answer answer = Answer.builder()
                         .application(application)
                         .question(question)

--- a/src/main/java/com/ryc/api/v1/common/aop/annotation/HasAnyRoleSecured.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/annotation/HasAnyRoleSecured.java
@@ -1,0 +1,11 @@
+package com.ryc.api.v1.common.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HasAnyRoleSecured {
+}

--- a/src/main/java/com/ryc/api/v1/common/aop/annotation/HasPresidentRoleSecured.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/annotation/HasPresidentRoleSecured.java
@@ -1,0 +1,11 @@
+package com.ryc.api.v1.common.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HasPresidentRoleSecured {
+}

--- a/src/main/java/com/ryc/api/v1/common/aop/aspect/ClubRoleAuthenticationAspect.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/aspect/ClubRoleAuthenticationAspect.java
@@ -1,0 +1,121 @@
+package com.ryc.api.v1.common.aop.aspect;
+
+import com.ryc.api.v1.common.aop.service.ClubRoleAuthenticationService;
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
+import com.ryc.api.v1.common.exception.code.PermisssionErrorCode;
+import com.ryc.api.v1.common.exception.custom.NoPermissionException;
+import com.ryc.api.v1.role.domain.ClubRole;
+import com.ryc.api.v1.security.dto.CustomUserDetail;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ClubRoleAuthenticationAspect {
+    private final ClubRoleAuthenticationService clubRoleAuthenticationService;
+
+    /**
+     * 회장 자격 검증
+     */
+    // GET 요청 처리: clubId가 @RequestParam으로 전달된 경우
+    @Before("isPresidentRoleSecured() && isGetRequest() && args(clubId,..)")
+    public void checkPresidentRoleForGet(String clubId) {
+        validateClubRole(clubId, ClubRole.PRESIDENT);
+    }
+
+    // POST 요청 처리: clubId가 @RequestBody로 전달된 경우
+    @Before("isPresidentRoleSecured() && isPostRequest() && args(body)")
+    public void checkPresidentRoleForPost(Object body) {
+        try {
+            Field clubRoleField = body.getClass().getDeclaredField("clubRoleSecuredDto");
+            clubRoleField.setAccessible(true);
+            Object clubRoleSecuredDto = clubRoleField.get(body);
+
+            if (clubRoleSecuredDto != null) {
+                validateClubRole(((ClubRoleSecuredDto) clubRoleSecuredDto).clubId(), ClubRole.PRESIDENT);
+            } else {
+                throw new IllegalArgumentException("clubRoleSecuredDto field should not be null.");
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // 필드가 없거나 접근할 수 없을 때 예외 처리
+            throw new IllegalArgumentException("The request body must contain a field named 'clubRoleSecuredDto'.", e);
+        }
+    }
+
+    /**
+     * 회장 또는 동아리원인지 자격 검증
+     */
+    // GET 요청 처리: clubId가 @RequestParam으로 전달된 경우
+    @Before("isAnyRoleSecured() && isGetRequest() && args(clubId,..)")
+    public void checkClubRoleForGet(String clubId) {
+        validateAnyClubRole(clubId);
+    }
+
+    // POST 요청 처리: clubId가 @RequestBody로 전달된 경우
+    @Before("isAnyRoleSecured() && isPostRequest() && args(body)")
+    public void checkClubRoleForPost(Object body) {
+        try {
+            Field clubRoleField = body.getClass().getDeclaredField("clubRoleSecuredDto");
+            clubRoleField.setAccessible(true);
+            Object clubRoleSecuredDto = clubRoleField.get(body);
+
+            if (clubRoleSecuredDto != null) {
+                validateAnyClubRole(((ClubRoleSecuredDto) clubRoleSecuredDto).clubId());
+            } else {
+                throw new IllegalArgumentException("clubRoleSecuredDto field should not be null.");
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            // 필드가 없거나 접근할 수 없을 때 예외 처리
+            throw new IllegalArgumentException("The request body must contain a field named 'clubRoleSecuredDto'.", e);
+        }
+    }
+
+    // Pointcut: HasPresidentRoleSecured 어노테이션에서만 실행
+    @Pointcut("@annotation(com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured)")
+    public void isPresidentRoleSecured() {
+    }
+
+    // Pointcut: HasAnyRoleSecured 어노테이션에서만 실행
+    @Pointcut("@annotation(com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured)")
+    public void isAnyRoleSecured() {
+    }
+
+    // Pointcut: GET 요청에서만 실행
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.GetMapping)")
+    public void isGetRequest() {
+    }
+
+    // Pointcut: POST 요청에서만 실행
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+    public void isPostRequest() {
+    }
+
+    //동아리 내 특정 권한 확인 공통로직
+    private void validateClubRole(String clubId, ClubRole clubRole) {
+        CustomUserDetail userDetails = (CustomUserDetail) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = userDetails.getId();
+
+        if (!clubRoleAuthenticationService.hasClubRole(userId, clubId, clubRole)) {
+            if (clubRole == ClubRole.PRESIDENT)
+                throw new NoPermissionException(PermisssionErrorCode.FORBIDDEN_NOT_CLUB_PRESIDENT);
+            if (clubRole == ClubRole.MEMBER)
+                throw new NoPermissionException(PermisssionErrorCode.FORBIDDEN_NOT_CLUB_MEMBER);
+        }
+    }
+
+    //동아리 내 권한 유무 확인 공통로직
+    private void validateAnyClubRole(String clubId) {
+        CustomUserDetail userDetails = (CustomUserDetail) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = userDetails.getId();
+
+        if (!clubRoleAuthenticationService.hasAnyClubRole(userId, clubId))
+            throw new NoPermissionException(PermisssionErrorCode.FORBIDDEN_NOT_CLUB_ANY_ROLE);
+    }
+}

--- a/src/main/java/com/ryc/api/v1/common/aop/aspect/ClubRoleAuthenticationAspect.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/aspect/ClubRoleAuthenticationAspect.java
@@ -24,8 +24,9 @@ public class ClubRoleAuthenticationAspect {
     /**
      * 회장 자격 검증
      */
-    // GET 요청 처리: clubId가 @RequestParam으로 전달된 경우
-    @Before("isPresidentRoleSecured() && isGetRequest() && args(clubId,..)")
+    // GET,PATCH 요청 처리: clubId가 @RequestParam으로 전달된 경우
+    @Before("(isPresidentRoleSecured() && isGetRequest() && args(clubId,..)) " +
+            "|| (isPresidentRoleSecured() && isPatchRequest() && args(clubId,..))")
     public void checkPresidentRoleForGet(String clubId) {
         validateClubRole(clubId, ClubRole.PRESIDENT);
     }
@@ -52,8 +53,9 @@ public class ClubRoleAuthenticationAspect {
     /**
      * 회장 또는 동아리원인지 자격 검증
      */
-    // GET 요청 처리: clubId가 @RequestParam으로 전달된 경우
-    @Before("isAnyRoleSecured() && isGetRequest() && args(clubId,..)")
+    // GET, PATCH 요청 처리: clubId가 @RequestParam으로 전달된 경우
+    @Before("isAnyRoleSecured() && isGetRequest() && args(clubId,..)" +
+            "|| isAnyRoleSecured() && isPatchRequest() && args(clubId,..)")
     public void checkClubRoleForGet(String clubId) {
         validateAnyClubRole(clubId);
     }
@@ -95,6 +97,11 @@ public class ClubRoleAuthenticationAspect {
     // Pointcut: POST 요청에서만 실행
     @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
     public void isPostRequest() {
+    }
+
+    // Pointcut: PATCH 요청에서만 실행
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+    public void isPatchRequest() {
     }
 
     //동아리 내 특정 권한 확인 공통로직

--- a/src/main/java/com/ryc/api/v1/common/aop/service/ClubRoleAuthenticationService.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/service/ClubRoleAuthenticationService.java
@@ -1,0 +1,8 @@
+package com.ryc.api.v1.common.aop.service;
+
+import com.ryc.api.v1.role.domain.ClubRole;
+
+public interface ClubRoleAuthenticationService {
+    boolean hasClubRole(String userId, String clubId, ClubRole clubRole);
+    boolean hasAnyClubRole(String userId, String clubId);
+}

--- a/src/main/java/com/ryc/api/v1/common/aop/service/ClubRoleAuthenticationServiceImpl.java
+++ b/src/main/java/com/ryc/api/v1/common/aop/service/ClubRoleAuthenticationServiceImpl.java
@@ -1,0 +1,27 @@
+package com.ryc.api.v1.common.aop.service;
+
+import com.ryc.api.v1.role.domain.ClubRole;
+import com.ryc.api.v1.role.repository.UserClubRoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClubRoleAuthenticationServiceImpl implements ClubRoleAuthenticationService {
+    private final UserClubRoleRepository userClubRoleRepository;
+
+    @Override
+    @Transactional
+    public boolean hasClubRole(String userId, String clubId, ClubRole clubRole) {
+        return userClubRoleRepository.findByClubIdAndUserId(clubId, userId)
+                .map(userClubRole -> userClubRole.getClubRole() == clubRole)
+                .orElse(false);
+    }
+
+    @Override
+    @Transactional
+    public boolean hasAnyClubRole(String userId, String clubId) {
+        return userClubRoleRepository.findByClubIdAndUserId(clubId, userId).isPresent();
+    }
+}

--- a/src/main/java/com/ryc/api/v1/common/dto/ClubRoleSecuredDto.java
+++ b/src/main/java/com/ryc/api/v1/common/dto/ClubRoleSecuredDto.java
@@ -1,0 +1,12 @@
+package com.ryc.api.v1.common.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+/**
+ *
+ * @param clubId
+ * Api 요청시 동아리 내 권한 확인시 필요한 데이터 값(clubId) 전달 DTO
+ */
+public record ClubRoleSecuredDto(@NotEmpty(message = "clubId shouldn't be empty") String clubId) {
+}

--- a/src/main/java/com/ryc/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,95 @@
+package com.ryc.api.v1.common.exception;
+
+import com.ryc.api.v1.common.exception.code.CommonErrorCode;
+import com.ryc.api.v1.common.exception.code.ErrorCode;
+import com.ryc.api.v1.common.exception.custom.NoPermissionException;
+import com.ryc.api.v1.common.exception.response.ErrorResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(NoPermissionException.class)
+    public ResponseEntity<Object> handleNoPermissionException(NoPermissionException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(e, errorCode);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllExceptions(Exception e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    //handleExceptionInternal Method
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(e, errorCode));
+    }
+
+    //makeErrorResponse Method
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(message)
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponse(BindException e, ErrorCode errorCode) {
+        List<ErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .errors(validationErrorList)
+                .build();
+    }
+}
+

--- a/src/main/java/com/ryc/api/v1/common/exception/code/CommonErrorCode.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/code/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package com.ryc.api.v1.common.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode{
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ryc/api/v1/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/code/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.ryc.api.v1.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/ryc/api/v1/common/exception/code/PermisssionErrorCode.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/code/PermisssionErrorCode.java
@@ -1,0 +1,15 @@
+package com.ryc.api.v1.common.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PermisssionErrorCode implements ErrorCode{
+    FORBIDDEN_NOT_CLUB_PRESIDENT(HttpStatus.FORBIDDEN, "You are not the club president. Access forbidden."),
+    FORBIDDEN_NOT_CLUB_MEMBER(HttpStatus.FORBIDDEN, "You are not the club member. Access forbidden.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ryc/api/v1/common/exception/code/PermisssionErrorCode.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/code/PermisssionErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PermisssionErrorCode implements ErrorCode{
     FORBIDDEN_NOT_CLUB_PRESIDENT(HttpStatus.FORBIDDEN, "You are not the club president. Access forbidden."),
-    FORBIDDEN_NOT_CLUB_MEMBER(HttpStatus.FORBIDDEN, "You are not the club member. Access forbidden.");
+    FORBIDDEN_NOT_CLUB_MEMBER(HttpStatus.FORBIDDEN, "You are not the club member. Access forbidden."),
+    FORBIDDEN_NOT_CLUB_ANY_ROLE(HttpStatus.FORBIDDEN, "You don't have any club role. Access forbidden.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ryc/api/v1/common/exception/custom/NoPermissionException.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/custom/NoPermissionException.java
@@ -1,0 +1,11 @@
+package com.ryc.api.v1.common.exception.custom;
+
+import com.ryc.api.v1.common.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NoPermissionException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ryc/api/v1/common/exception/response/ErrorResponse.java
+++ b/src/main/java/com/ryc/api/v1/common/exception/response/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.ryc.api.v1.common.exception.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Builder
+    public record ValidationError(String field, String message) {
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/ryc/api/v1/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/controller/EvaluationController.java
@@ -1,5 +1,6 @@
 package com.ryc.api.v1.evaluation.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
 import com.ryc.api.v1.evaluation.dto.request.CreateEvaluationRequest;
 import com.ryc.api.v1.evaluation.dto.response.CreateEvaluationResponse;
 import com.ryc.api.v1.evaluation.dto.response.GetEvaluationResponse;
@@ -21,6 +22,7 @@ import java.util.List;
 public class EvaluationController {
     private final EvaluationService evaluationService;
 
+    @HasAnyRoleSecured
     @PostMapping("/")
     public ResponseEntity<?> createEvaluation(@Valid @RequestBody CreateEvaluationRequest body) {
         try {
@@ -31,8 +33,10 @@ public class EvaluationController {
         }
     }
 
+    @HasAnyRoleSecured
     @GetMapping
-    public ResponseEntity<?> getEvaluations(@NotEmpty @RequestParam String stepId,
+    public ResponseEntity<?> getEvaluations(@NotEmpty @RequestParam String clubId,
+                                            @NotEmpty @RequestParam String stepId,
                                             @RequestParam(required = false) List<String> applicantIdList) {
         try {
             List<GetEvaluationResponse> response = evaluationService.getEvaluations(stepId, applicantIdList);

--- a/src/main/java/com/ryc/api/v1/evaluation/controller/PassedController.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/controller/PassedController.java
@@ -1,5 +1,7 @@
 package com.ryc.api.v1.evaluation.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.evaluation.dto.request.CreatePasserRequest;
 import com.ryc.api.v1.evaluation.dto.response.CreatePasserResponse;
 import com.ryc.api.v1.evaluation.dto.response.GetPasserResponse;
@@ -21,6 +23,7 @@ import java.util.List;
 public class PassedController {
     private final PassedService passedService;
 
+    @HasPresidentRoleSecured
     @PostMapping("/")
     public ResponseEntity<?> createPasser(@Valid @RequestBody CreatePasserRequest body) {
         try {
@@ -31,9 +34,10 @@ public class PassedController {
         }
     }
 
+    @HasAnyRoleSecured
     @GetMapping("/")
-    public ResponseEntity<?> getPasser(
-            @NotEmpty @RequestParam String stepId) {
+    public ResponseEntity<?> getPasser(@NotEmpty @RequestParam String clubId,
+                                       @NotEmpty @RequestParam String stepId) {
         try {
             List<GetPasserResponse> response = passedService.getPasser(stepId);
             return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/ryc/api/v1/evaluation/controller/PermissionController.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/controller/PermissionController.java
@@ -1,5 +1,7 @@
 package com.ryc.api.v1.evaluation.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.common.constant.RequestStatus;
 import com.ryc.api.v1.evaluation.dto.request.CreatePermissionApplicationRequest;
 import com.ryc.api.v1.evaluation.dto.request.UpdatePermissionStatusRequest;
@@ -25,6 +27,7 @@ import java.util.List;
 public class PermissionController {
     private final PermissionService permissionService;
 
+    @HasAnyRoleSecured
     @PostMapping("/request")
     public ResponseEntity<?> createEvaluationPermissionRequest(@Valid @RequestBody CreatePermissionApplicationRequest body) {
         try {
@@ -35,8 +38,10 @@ public class PermissionController {
         }
     }
 
+    @HasPresidentRoleSecured
     @GetMapping("/requests")
     public ResponseEntity<?> getEvaluationPermissionRequest(
+            @NotEmpty @RequestParam String clubId,
             @NotEmpty @RequestParam String recruitmentId,
             @RequestParam(required = false, defaultValue = "ALL") RequestStatus status) {
         try {
@@ -47,6 +52,7 @@ public class PermissionController {
         }
     }
 
+    @HasPresidentRoleSecured
     @PostMapping("/status")
     public ResponseEntity<?> updateEvaluationPermissionStatus(@Valid @RequestBody UpdatePermissionStatusRequest body) {
         try {
@@ -57,8 +63,10 @@ public class PermissionController {
         }
     }
 
+    @HasPresidentRoleSecured
     @GetMapping("/users")
     public ResponseEntity<?> getEvaluationAuthorizedUserList(
+            @NotEmpty @RequestParam String clubId,
             @NotEmpty @RequestParam String recruitmentId) {
         try {
             List<GetEvaluationAuthorizedUserResponse> response = permissionService.findEvaluationAuthorizedUsers(recruitmentId);

--- a/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreateEvaluationRequest.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreateEvaluationRequest.java
@@ -1,13 +1,16 @@
 package com.ryc.api.v1.evaluation.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
-public record CreateEvaluationRequest(@NotEmpty(message = "recruitmentId shouldn't be empty") String recruitmentId,
-                                      @NotEmpty(message = "stepId shouldn't be empty") String stepId,
-                                      @NotEmpty(message = "applicantId shouldn't be empty") String applicantId,
-                                      @NotNull(message = "score shouldn't be empty") BigDecimal score,
-                                      @NotEmpty(message = "comment shouldn't be empty") String comment) {
+public record CreateEvaluationRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "recruitmentId shouldn't be empty") String recruitmentId,
+        @NotEmpty(message = "stepId shouldn't be empty") String stepId,
+        @NotEmpty(message = "applicantId shouldn't be empty") String applicantId,
+        @NotNull(message = "score shouldn't be empty") BigDecimal score,
+        @NotEmpty(message = "comment shouldn't be empty") String comment) {
 }

--- a/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreatePasserRequest.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreatePasserRequest.java
@@ -1,8 +1,12 @@
 package com.ryc.api.v1.evaluation.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-public record CreatePasserRequest(@NotEmpty(message = "clubId shouldn't be empty") String clubId,
-                                  @NotEmpty(message = "stepId shouldn't be empty") String stepId,
-                                  @NotEmpty(message = "applicantId shouldn't be empty") String applicantId) {
+public record CreatePasserRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "clubId shouldn't be empty") String clubId,
+        @NotEmpty(message = "stepId shouldn't be empty") String stepId,
+        @NotEmpty(message = "applicantId shouldn't be empty") String applicantId) {
 }

--- a/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreatePermissionApplicationRequest.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/dto/request/CreatePermissionApplicationRequest.java
@@ -1,6 +1,10 @@
 package com.ryc.api.v1.evaluation.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-public record CreatePermissionApplicationRequest(@NotEmpty(message = "recruitmentId shouldn't be empty") String recruitmentId) {
+public record CreatePermissionApplicationRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "recruitmentId shouldn't be empty") String recruitmentId) {
 }

--- a/src/main/java/com/ryc/api/v1/evaluation/dto/request/UpdatePermissionStatusRequest.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/dto/request/UpdatePermissionStatusRequest.java
@@ -1,10 +1,12 @@
 package com.ryc.api.v1.evaluation.dto.request;
 
 import com.ryc.api.v1.common.constant.RequestStatus;
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdatePermissionStatusRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
         @NotEmpty(message = "permissionApplicationId shouldn't be empty") String permissionApplicationId,
         @NotNull(message = "requestStatus shouldn't be empty") RequestStatus requestStatus){
 }

--- a/src/main/java/com/ryc/api/v1/evaluation/service/PassedServiceImpl.java
+++ b/src/main/java/com/ryc/api/v1/evaluation/service/PassedServiceImpl.java
@@ -74,6 +74,7 @@ public class PassedServiceImpl implements PassedService {
         if (stepPassers.isEmpty())
             throw new NoSuchElementException("passers not found");
 
+        //TODO: 동아리원이 조회 시에는, 개인정보를 제외한 이름만 반환하도록 변경
         List<GetPasserResponse> responses = new ArrayList<>();
         for (StepPasser stepPasser : stepPassers) {
             ApplicantDto applicantDto = stepPasser.getApplicant().toApplicantDto();

--- a/src/main/java/com/ryc/api/v1/interview/controller/InterviewController.java
+++ b/src/main/java/com/ryc/api/v1/interview/controller/InterviewController.java
@@ -1,5 +1,7 @@
 package com.ryc.api.v1.interview.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.interview.dto.request.CreateInterviewAssignmentRequest;
 import com.ryc.api.v1.interview.dto.request.CreateInterviewRequest;
 import com.ryc.api.v1.interview.dto.response.CreateInterviewAssignmentResponse;
@@ -24,6 +26,7 @@ import java.util.List;
 public class InterviewController {
     private final InterviewService interviewService;
 
+    @HasPresidentRoleSecured
     @PostMapping("/")
     public ResponseEntity<?> createInterview(@Valid @RequestBody CreateInterviewRequest body) {
         try {
@@ -34,17 +37,20 @@ public class InterviewController {
         }
     }
 
-    @GetMapping("/")
-    public ResponseEntity<?> getInterviewScheduleList(
-            @NotEmpty @RequestParam String stepId) {
+    @HasAnyRoleSecured
+    @GetMapping("/applicants")
+    public ResponseEntity<?> getAllApplicantsByInterview(@NotEmpty @RequestParam String clubId,
+                                                         @RequestParam(required = false, defaultValue = "none") String interviewId,
+                                                         @RequestParam(required = false, defaultValue = "none") String stepId) {
         try {
-            List<GetInterviewScheduleResponse> response = interviewService.findInterviewSchedules(stepId);
+            GetAllApplicantByInterviewResponse response = interviewService.getAllApplicantsByInterview(interviewId, stepId);
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
 
+    @HasPresidentRoleSecured
     @PostMapping("/assignment")
     public ResponseEntity<?> createInterviewAssignment(@Valid @RequestBody CreateInterviewAssignmentRequest body) {
         try {
@@ -55,14 +61,15 @@ public class InterviewController {
         }
     }
 
-    @GetMapping("/applicants")
-    public ResponseEntity<?> getAllApplicantsByInterview(@RequestParam(required = false, defaultValue = "none") String interviewId,
-                                                         @RequestParam(required = false, defaultValue = "none") String stepId) {
+    @HasAnyRoleSecured
+    @GetMapping("/")
+    public ResponseEntity<?> getInterviewScheduleList(@NotEmpty @RequestParam String clubId,
+                                                      @NotEmpty @RequestParam String stepId) {
         try {
-            GetAllApplicantByInterviewResponse response = interviewService.getAllApplicantsByInterview(interviewId,stepId);
+            List<GetInterviewScheduleResponse> response = interviewService.findInterviewSchedules(stepId);
             return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/ryc/api/v1/interview/dto/request/CreateInterviewAssignmentRequest.java
+++ b/src/main/java/com/ryc/api/v1/interview/dto/request/CreateInterviewAssignmentRequest.java
@@ -1,12 +1,16 @@
 package com.ryc.api.v1.interview.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 
 /**
  * intervieweeId 는 applicant의 id이며, interviewerId는 user의 id이다.
  */
 public record CreateInterviewAssignmentRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
         @NotEmpty(message = "assignmentDtos shouldn't be empty") List<assignmentDto> assignmentDtos) {
 
     public record assignmentDto(@NotEmpty(message = "interviewId shouldn't be empty") String interviewId,

--- a/src/main/java/com/ryc/api/v1/interview/dto/request/CreateInterviewRequest.java
+++ b/src/main/java/com/ryc/api/v1/interview/dto/request/CreateInterviewRequest.java
@@ -1,14 +1,18 @@
 package com.ryc.api.v1.interview.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Builder
-public record CreateInterviewRequest(@NotEmpty(message = "stepId shouldn't be empty") String stepId,
-                                     @NotEmpty(message = "interviewSchedules shouldn't be empty") List<InterviewScheduleDto> interviewSchedules) {
+public record CreateInterviewRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "stepId shouldn't be empty") String stepId,
+        @NotEmpty(message = "interviewSchedules shouldn't be empty") List<InterviewScheduleDto> interviewSchedules) {
 
     @Builder
     public record InterviewScheduleDto(@NotEmpty(message = "interviewDate shouldn't be empty") LocalDate interviewDate,

--- a/src/main/java/com/ryc/api/v1/interview/service/InterviewService.java
+++ b/src/main/java/com/ryc/api/v1/interview/service/InterviewService.java
@@ -11,9 +11,10 @@ import java.util.List;
 
 public interface InterviewService {
     List<CreateInterviewResponse> createInterview(CreateInterviewRequest body);
+
+    GetAllApplicantByInterviewResponse getAllApplicantsByInterview(String interviewId, String stepId);
+
     CreateInterviewAssignmentResponse createInterviewAssignment(CreateInterviewAssignmentRequest body);
 
     List<GetInterviewScheduleResponse> findInterviewSchedules(String stepId);
-
-    GetAllApplicantByInterviewResponse getAllApplicantsByInterview(String interviewId, String stepId);
 }

--- a/src/main/java/com/ryc/api/v1/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/com/ryc/api/v1/interview/service/InterviewServiceImpl.java
@@ -48,8 +48,6 @@ public class InterviewServiceImpl implements InterviewService {
     @Override
     @Transactional
     public List<CreateInterviewResponse> createInterview(CreateInterviewRequest body) {
-        //TODO: 회장 권한 확인하기
-
         Step step = stepRepository.findById(body.stepId())
                 .orElseThrow(() -> new NoSuchElementException("Step not found"));
 
@@ -83,7 +81,6 @@ public class InterviewServiceImpl implements InterviewService {
     @Override
     @Transactional
     public CreateInterviewAssignmentResponse createInterviewAssignment(CreateInterviewAssignmentRequest body) {
-        //TODO: 회장권한 확인
         List<CreateInterviewAssignmentRequest.assignmentDto> assignmentDtos
                 = body.assignmentDtos();
 
@@ -105,6 +102,7 @@ public class InterviewServiceImpl implements InterviewService {
                 interviewees.add(interviewee);
             }
 
+            //TODO: 해당 interviewer(user)가 해당 동아리 소속인지 검사하는 로직 추가 필요
             for (String interviewerId : assignment.interviewerIdList()) {
                 User user = userRepository.findById(interviewerId)
                         .orElseThrow(() -> new NoSuchElementException("interviewer not found"));

--- a/src/main/java/com/ryc/api/v1/passer/controller/PasserController.java
+++ b/src/main/java/com/ryc/api/v1/passer/controller/PasserController.java
@@ -1,6 +1,7 @@
 package com.ryc.api.v1.passer.controller;
 
-import com.ryc.api.v1.applicant.dto.response.GetAllApplicantResponse;
+import com.ryc.api.v1.common.aop.annotation.HasAnyRoleSecured;
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.passer.dto.request.CreateFinalPasserRequest;
 import com.ryc.api.v1.passer.dto.response.CreateFinalPasserResponse;
 import com.ryc.api.v1.passer.dto.response.GetAllFinalPasserResponse;
@@ -21,6 +22,7 @@ import java.util.List;
 public class PasserController {
     private final PasserService passerService;
 
+    @HasPresidentRoleSecured
     @PostMapping("/final")
     public ResponseEntity<?> createFinalPasser(@Valid @RequestBody CreateFinalPasserRequest body) {
         try {
@@ -31,8 +33,10 @@ public class PasserController {
         }
     }
 
+    @HasAnyRoleSecured
     @GetMapping("/final")
-    public ResponseEntity<?> getAllFinalPasser(@RequestParam(required = true) String recruitmentId) {
+    public ResponseEntity<?> getAllFinalPasser(@RequestParam(required = true) String clubId,
+                                               @RequestParam(required = true) String recruitmentId) {
         try {
             List<GetAllFinalPasserResponse> response = passerService.findAllFinalPasser(recruitmentId);
             return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/ryc/api/v1/passer/dto/request/CreateFinalPasserRequest.java
+++ b/src/main/java/com/ryc/api/v1/passer/dto/request/CreateFinalPasserRequest.java
@@ -1,8 +1,12 @@
 package com.ryc.api.v1.passer.dto.request;
 
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record CreateFinalPasserRequest(@NotEmpty(message = "applicantIdList shouldn't be empty") List<String> applicantIdList) {
+public record CreateFinalPasserRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "applicantIdList shouldn't be empty") List<String> applicantIdList) {
 }

--- a/src/main/java/com/ryc/api/v1/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/ryc/api/v1/recruitment/controller/RecruitmentController.java
@@ -1,10 +1,9 @@
 package com.ryc.api.v1.recruitment.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.recruitment.dto.request.CreateRecruitmentRequest;
 import com.ryc.api.v1.recruitment.dto.response.CreateRecruitmentResponse;
 import com.ryc.api.v1.recruitment.service.RecruitmentService;
-import com.ryc.api.v1.role.dto.request.ClubRoleRequest;
-import com.ryc.api.v1.role.dto.response.ClubRoleResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecruitmentController {
     private final RecruitmentService recruitmentService;
 
+    @HasPresidentRoleSecured
     @PostMapping("/")
     public ResponseEntity<?> createRecruitment(@Valid @RequestBody CreateRecruitmentRequest body) {
         try {
@@ -31,5 +31,4 @@ public class RecruitmentController {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }
     }
-
 }

--- a/src/main/java/com/ryc/api/v1/recruitment/dto/request/CreateRecruitmentRequest.java
+++ b/src/main/java/com/ryc/api/v1/recruitment/dto/request/CreateRecruitmentRequest.java
@@ -1,6 +1,7 @@
 package com.ryc.api.v1.recruitment.dto.request;
 
 import com.ryc.api.v1.club.domain.Club;
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import com.ryc.api.v1.recruitment.domain.Recruitment;
 import com.ryc.api.v1.recruitment.domain.Step;
 import com.ryc.api.v1.recruitment.domain.StepType;
@@ -11,10 +12,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-public record CreateRecruitmentRequest(@NotEmpty(message = "clubId shouldn't be empty") String clubId,
-                                       @NotEmpty(message = "clubId shouldn't be empty") String recruitmentName,
-                                       @NotNull(message = "clubId shouldn't be empty") LocalDate expireDate,
-                                       @NotEmpty List<RecruitmentStepDto> steps) {
+public record CreateRecruitmentRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
+        @NotEmpty(message = "clubId shouldn't be empty") String clubId,
+        @NotEmpty(message = "clubId shouldn't be empty") String recruitmentName,
+        @NotNull(message = "clubId shouldn't be empty") LocalDate expireDate,
+        @NotEmpty List<RecruitmentStepDto> steps) {
 
     public record RecruitmentStepDto(
             @NotEmpty String stepName,

--- a/src/main/java/com/ryc/api/v1/role/controller/RoleController.java
+++ b/src/main/java/com/ryc/api/v1/role/controller/RoleController.java
@@ -1,5 +1,6 @@
 package com.ryc.api.v1.role.controller;
 
+import com.ryc.api.v1.common.aop.annotation.HasPresidentRoleSecured;
 import com.ryc.api.v1.common.constant.RequestStatus;
 import com.ryc.api.v1.role.domain.ClubRole;
 import com.ryc.api.v1.role.dto.request.ClubRoleRequest;
@@ -35,6 +36,7 @@ public class RoleController {
         }
     }
 
+    @HasPresidentRoleSecured
     @GetMapping("/applications")
     public ResponseEntity<?> getClubRoleApplications(
             @NotEmpty @RequestParam String clubId,
@@ -48,6 +50,7 @@ public class RoleController {
         }
     }
 
+    @HasPresidentRoleSecured
     @PostMapping("application/status")
     public ResponseEntity<?> updateClubRoleApplicationStatus(@Valid @RequestBody UpdateStatusRequest body) {
         try {

--- a/src/main/java/com/ryc/api/v1/role/dto/request/UpdateStatusRequest.java
+++ b/src/main/java/com/ryc/api/v1/role/dto/request/UpdateStatusRequest.java
@@ -1,10 +1,12 @@
 package com.ryc.api.v1.role.dto.request;
 
 import com.ryc.api.v1.common.constant.RequestStatus;
+import com.ryc.api.v1.common.dto.ClubRoleSecuredDto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateStatusRequest(
+        @NotNull(message = "clubRoleSecuredDto shouldn't be null") ClubRoleSecuredDto clubRoleSecuredDto,
         @NotEmpty(message = "clubRoleApplicationId shouldn't be empty") String clubRoleApplicationId,
         @NotNull(message = "requestStatus shouldn't be empty") RequestStatus requestStatus) {
 }

--- a/src/main/java/com/ryc/api/v1/role/repository/UserClubRoleRepository.java
+++ b/src/main/java/com/ryc/api/v1/role/repository/UserClubRoleRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface UserClubRoleRepository extends JpaRepository<UserClubRole, String> {
     Optional<UserClubRole> findByClubAndUser(Club club, User user);
     Optional<UserClubRole> findByClubIdAndUser(String clubId, User user);
+    Optional<UserClubRole> findByClubIdAndUserId(String clubId, String userId);
 }


### PR DESCRIPTION
1. API호출시 controller 진입 전, 해당 요청자가 동아리 내 권한(PRESIDENT, MEMBER)을 가지고 있는지 확인하는 AOP 설정
> @HasAnyRoleSecured, @HasPresidentRoleSecured를 이용하여, api 호출시 선행적으로 요청자의 동아리내 권한을 확인하는 공통된 검증 로직을 AOP로 분리하였다.

2. 전역예외처리 (Global Exception Handling)
> @RestControllerAdvice를 이용하여, GlobalExceptionHandler를 구현하였다.

개발 과정
1. 공통된 권한 검증로직 AOP로 분리
https://sangjunn.notion.site/2-API-AOP-c9829d99c83744e3a58a639da1aa3bcf?pvs=4

2. 전역예외처리 (Global Exception Handling)
https://sangjunn.notion.site/1-GlobalExceptionHandling-4be834dcdc7142d692e7dcd03e78c4c7?pvs=4